### PR TITLE
Keep track of PID of process running job 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +705,7 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "log",
+ "nix",
  "pretty_env_logger",
  "serde_json",
  "tokio",
@@ -870,6 +884,12 @@ name = "vcpkg"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55d1e41d56121e07f1e223db0a4def204e45c85425f6a16d462fd07c8d10d74c"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "base64",
  "hyper",
  "hyper-tls",
+ "lazy_static",
  "log",
  "nix",
  "pretty_env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ log = "0.4"
 pretty_env_logger = "0.4"
 serde_json = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
+nix = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ pretty_env_logger = "0.4"
 serde_json = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 nix = "0.17"
+lazy_static = "1.4"

--- a/src/lib/api.rs
+++ b/src/lib/api.rs
@@ -8,8 +8,8 @@ use std::io::prelude::*;
 
 use super::config;
 
-pub const COMMIT_PENDING: &'static str ="pending";
-pub const COMMIT_SUCCESS: &'static str ="success";
+pub const COMMIT_PENDING: &'static str = "pending";
+pub const COMMIT_SUCCESS: &'static str = "success";
 pub const COMMIT_FAILURE: &'static str = "failure";
 
 pub async fn post_comment(comment: &str, pr_number: u64) -> Result<(), String> {

--- a/src/lib/cmd.rs
+++ b/src/lib/cmd.rs
@@ -35,10 +35,11 @@ async fn remote_cmd(job_id: &Uuid, args: &mut Vec<&str>, output: &mut File, job_
             let result = child.wait_with_output().expect("Ok");
             if !result.status.success() {
                 /*
-                   Check if Signal::SIGKILL was received. If it was the case
+                   Check if Signal::SIGINT was received. If it was the case
                    this is probably because the the job was canceled.
+                   exit code 130 is a result of Control-C/SIGINT
                 */
-                if result.status.to_string() == "signal: 9" {
+                if result.status.to_string() == "exit code: 130" {
                     let job_registry = job_registry.read().await;
                     let job: Arc<RwLock<job::JobDesc>>;
                     if let Some(j) = job_registry.jobs.get(job_id) {

--- a/src/lib/cmd.rs
+++ b/src/lib/cmd.rs
@@ -6,13 +6,13 @@ use crate::lib::job;
 
 use super::config;
 
-async fn remote_cmd(args: &mut Vec<&str>, output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
+async fn remote_cmd(args: &mut Vec<&str>, output: &mut File, curr_job: &Arc<RwLock<job::JobDesc>>) -> Result<(), String> {
     // TODO(azhng): let's finger cross this works.
     let output_file = output.try_clone().unwrap();
     let error_file = output.try_clone().unwrap();
     let cmd_process = Command::new("ssh")
         .arg(config::SEXXI_REMOTE_HOST)
-        .args(args.clone())
+        .args(&*args)
         .stdout(Stdio::from(output_file))
         .stderr(Stdio::from(error_file))
         .spawn();
@@ -31,8 +31,7 @@ async fn remote_cmd(args: &mut Vec<&str>, output: &mut File, curr_job: &Arc<RwLo
             }
         },
         Err(e) => {
-            error!("Command `{:?}` failed, server process didn't start: {}", args, e);
-            std::process::exit(1);
+            return Err(format!("Command `{:?}` failed, server process didn't start: {}", args, e));
         },
 
     }
@@ -40,43 +39,43 @@ async fn remote_cmd(args: &mut Vec<&str>, output: &mut File, curr_job: &Arc<RwLo
     Ok(())
 }
 
-async fn remote_git_cmd(args: &mut Vec<&str>, output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
+async fn remote_git_cmd(args: &mut Vec<&str>, output: &mut File, curr_job: &Arc<RwLock<job::JobDesc>>) -> Result<(), String> {
     let mut git_cmd = vec!["git", "-C", config::SEXXI_WORK_TREE];
     git_cmd.append(args);
     remote_cmd(&mut git_cmd, output, curr_job).await
 }
 
-pub async fn remote_git_reset_branch(output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
+pub async fn remote_git_reset_branch(output: &mut File, curr_job: &Arc<RwLock<job::JobDesc>>) -> Result<(), String> {
     let mut cmd = vec!["checkout", "master"];
     remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub async fn remote_git_fetch_upstream(output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
+pub async fn remote_git_fetch_upstream(output: &mut File, curr_job: &Arc<RwLock<job::JobDesc>>) -> Result<(), String> {
     let mut cmd = vec!["fetch", "--all", "-p"];
     remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub async fn remote_git_checkout_sha(sha: &str, bot_ref: &str, output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
+pub async fn remote_git_checkout_sha(sha: &str, bot_ref: &str, output: &mut File, curr_job: &Arc<RwLock<job::JobDesc>>) -> Result<(), String> {
     let mut cmd = vec!["checkout", sha, "-B", bot_ref];
     remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub async fn remote_git_rebase_upstream(output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
+pub async fn remote_git_rebase_upstream(output: &mut File, curr_job: &Arc<RwLock<job::JobDesc>>) -> Result<(), String> {
     let mut cmd = vec!["rebase", "upstream/master"];
     remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub async fn remote_git_push(bot_ref: &str, output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
+pub async fn remote_git_push(bot_ref: &str, output: &mut File, curr_job: &Arc<RwLock<job::JobDesc>>) -> Result<(), String> {
     let mut cmd = vec!["push", "origin", bot_ref, "-f"];
     remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub async fn remote_git_delete_branch(bot_ref: &str, output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
+pub async fn remote_git_delete_branch(bot_ref: &str, output: &mut File, curr_job: &Arc<RwLock<job::JobDesc>>) -> Result<(), String> {
     let mut cmd = vec!["branch", "-D", bot_ref];
     remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub async fn remote_test_rust_repo(output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
+pub async fn remote_test_rust_repo(output: &mut File, curr_job: &Arc<RwLock<job::JobDesc>>) -> Result<(), String> {
     let mut cmd = vec![
         "cd",
         config::SEXXI_WORK_TREE,

--- a/src/lib/cmd.rs
+++ b/src/lib/cmd.rs
@@ -1,9 +1,12 @@
 use std::fs::File;
 use std::process::{Command, Stdio};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use crate::lib::job;
 
 use super::config;
 
-fn remote_cmd(args: &mut Vec<&str>, output: &mut File) -> Result<(), String> {
+async fn remote_cmd(args: &mut Vec<&str>, output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
     // TODO(azhng): let's finger cross this works.
     let output_file = output.try_clone().unwrap();
     let error_file = output.try_clone().unwrap();
@@ -16,7 +19,11 @@ fn remote_cmd(args: &mut Vec<&str>, output: &mut File) -> Result<(), String> {
 
     match cmd_process {
         Ok(child) => {
-            println!("Server process with id {} is running command `{:?}`", child.id(), args);
+            info!("Server process with pid {} is running command `{:?}`", child.id(), args);
+            {
+                let mut job_info = curr_job.write().await;
+                job_info.pid = child.id();
+            }
 
             let result = child.wait_with_output().expect("Ok");
             if !result.status.success() {
@@ -24,7 +31,7 @@ fn remote_cmd(args: &mut Vec<&str>, output: &mut File) -> Result<(), String> {
             }
         },
         Err(e) => {
-            println!("Command `{:?}` failed, server process didn't start: {}", args, e);
+            error!("Command `{:?}` failed, server process didn't start: {}", args, e);
             std::process::exit(1);
         },
 
@@ -33,43 +40,43 @@ fn remote_cmd(args: &mut Vec<&str>, output: &mut File) -> Result<(), String> {
     Ok(())
 }
 
-fn remote_git_cmd(args: &mut Vec<&str>, output: &mut File) -> Result<(), String> {
+async fn remote_git_cmd(args: &mut Vec<&str>, output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
     let mut git_cmd = vec!["git", "-C", config::SEXXI_WORK_TREE];
     git_cmd.append(args);
-    remote_cmd(&mut git_cmd, output)
+    remote_cmd(&mut git_cmd, output, curr_job).await
 }
 
-pub fn remote_git_reset_branch(output: &mut File) -> Result<(), String> {
+pub async fn remote_git_reset_branch(output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
     let mut cmd = vec!["checkout", "master"];
-    remote_git_cmd(&mut cmd, output)
+    remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub fn remote_git_fetch_upstream(output: &mut File) -> Result<(), String> {
+pub async fn remote_git_fetch_upstream(output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
     let mut cmd = vec!["fetch", "--all", "-p"];
-    remote_git_cmd(&mut cmd, output)
+    remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub fn remote_git_checkout_sha(sha: &str, bot_ref: &str, output: &mut File) -> Result<(), String> {
+pub async fn remote_git_checkout_sha(sha: &str, bot_ref: &str, output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
     let mut cmd = vec!["checkout", sha, "-B", bot_ref];
-    remote_git_cmd(&mut cmd, output)
+    remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub fn remote_git_rebase_upstream(output: &mut File) -> Result<(), String> {
+pub async fn remote_git_rebase_upstream(output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
     let mut cmd = vec!["rebase", "upstream/master"];
-    remote_git_cmd(&mut cmd, output)
+    remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub fn remote_git_push(bot_ref: &str, output: &mut File) -> Result<(), String> {
+pub async fn remote_git_push(bot_ref: &str, output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
     let mut cmd = vec!["push", "origin", bot_ref, "-f"];
-    remote_git_cmd(&mut cmd, output)
+    remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub fn remote_git_delete_branch(bot_ref: &str, output: &mut File) -> Result<(), String> {
+pub async fn remote_git_delete_branch(bot_ref: &str, output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
     let mut cmd = vec!["branch", "-D", bot_ref];
-    remote_git_cmd(&mut cmd, output)
+    remote_git_cmd(&mut cmd, output, curr_job).await
 }
 
-pub fn remote_test_rust_repo(output: &mut File) -> Result<(), String> {
+pub async fn remote_test_rust_repo(output: &mut File, curr_job: &Arc<RwLock<job::JobInfo>>) -> Result<(), String> {
     let mut cmd = vec![
         "cd",
         config::SEXXI_WORK_TREE,
@@ -79,5 +86,5 @@ pub fn remote_test_rust_repo(output: &mut File) -> Result<(), String> {
         "-i",
         "-j32",
     ];
-    remote_cmd(&mut cmd, output)
+    remote_cmd(&mut cmd, output, curr_job).await
 }

--- a/src/lib/cmd.rs
+++ b/src/lib/cmd.rs
@@ -2,12 +2,14 @@ use std::fs::File;
 use std::process::{Command, Stdio};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use uuid::Uuid;
+use nix::sys::signal::{self, Signal};
+
 use crate::lib::job;
 
 use super::config;
 
-async fn remote_cmd(args: &mut Vec<&str>, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
-    // TODO(azhng): let's finger cross this works.
+async fn remote_cmd(job_id: &Uuid, args: &mut Vec<&str>, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
     let output_file = output.try_clone().unwrap();
     let error_file = output.try_clone().unwrap();
     let cmd_process = Command::new("ssh")
@@ -23,7 +25,7 @@ async fn remote_cmd(args: &mut Vec<&str>, output: &mut File, job_registry: &Arc<
             {
                 let job_registry = job_registry.read().await;
                 let job: Arc<RwLock<job::JobDesc>>;
-                if let Some(j) = job_registry.jobs.get(&job_registry.running_jobs) {
+                if let Some(j) = job_registry.jobs.get(job_id) {
                     job = j.clone();
                     let mut job = job.write().await;
                     job.pid = child.id();
@@ -32,6 +34,19 @@ async fn remote_cmd(args: &mut Vec<&str>, output: &mut File, job_registry: &Arc<
 
             let result = child.wait_with_output().expect("Ok");
             if !result.status.success() {
+                /*
+                   Check if Signal::SIGKILL was received. If it was the case
+                   this is probably because the the job was canceled.
+                */
+                if result.status.to_string() == "signal: 9" {
+                    let job_registry = job_registry.read().await;
+                    let job: Arc<RwLock<job::JobDesc>>;
+                    if let Some(j) = job_registry.jobs.get(job_id) {
+                        job = j.clone();
+                        let mut job = job.write().await;
+                        job.status = job::JobStatus::Canceled;
+                    }
+                }
                 return Err(format!("remote command failed: {}", result.status));
             }
         },
@@ -44,43 +59,43 @@ async fn remote_cmd(args: &mut Vec<&str>, output: &mut File, job_registry: &Arc<
     Ok(())
 }
 
-async fn remote_git_cmd(args: &mut Vec<&str>, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+async fn remote_git_cmd(job_id: &Uuid, args: &mut Vec<&str>, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
     let mut git_cmd = vec!["git", "-C", config::SEXXI_WORK_TREE];
     git_cmd.append(args);
-    remote_cmd(&mut git_cmd, output, job_registry).await
+    remote_cmd(job_id, &mut git_cmd, output, job_registry).await
 }
 
-pub async fn remote_git_reset_branch(output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_reset_branch(job_id: &Uuid, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
     let mut cmd = vec!["checkout", "master"];
-    remote_git_cmd(&mut cmd, output, job_registry).await
+    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
 }
 
-pub async fn remote_git_fetch_upstream(output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_fetch_upstream(job_id: &Uuid, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
     let mut cmd = vec!["fetch", "--all", "-p"];
-    remote_git_cmd(&mut cmd, output, job_registry).await
+    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
 }
 
-pub async fn remote_git_checkout_sha(sha: &str, bot_ref: &str, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_checkout_sha(job_id: &Uuid, sha: &str, bot_ref: &str, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
     let mut cmd = vec!["checkout", sha, "-B", bot_ref];
-    remote_git_cmd(&mut cmd, output, job_registry).await
+    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
 }
 
-pub async fn remote_git_rebase_upstream(output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_rebase_upstream(job_id: &Uuid, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
     let mut cmd = vec!["rebase", "upstream/master"];
-    remote_git_cmd(&mut cmd, output, job_registry).await
+    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
 }
 
-pub async fn remote_git_push(bot_ref: &str, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_push(job_id: &Uuid, bot_ref: &str, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
     let mut cmd = vec!["push", "origin", bot_ref, "-f"];
-    remote_git_cmd(&mut cmd, output, job_registry).await
+    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
 }
 
-pub async fn remote_git_delete_branch(bot_ref: &str, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_delete_branch(job_id: &Uuid, bot_ref: &str, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
     let mut cmd = vec!["branch", "-D", bot_ref];
-    remote_git_cmd(&mut cmd, output, job_registry).await
+    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
 }
 
-pub async fn remote_test_rust_repo(output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_test_rust_repo(job_id: &Uuid, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
     let mut cmd = vec![
         "cd",
         config::SEXXI_WORK_TREE,
@@ -90,5 +105,5 @@ pub async fn remote_test_rust_repo(output: &mut File, job_registry: &Arc<RwLock<
         "-i",
         "-j32",
     ];
-    remote_cmd(&mut cmd, output, job_registry).await
+    remote_cmd(job_id, &mut cmd, output, job_registry).await
 }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -1,3 +1,6 @@
+use std::env;
+use lazy_static::lazy_static;
+
 pub const REVIEW_REQUESTED: &'static str = "review_requested";
 pub const REVIEWER: &'static str = "sexxi-bot";
 // TODO(azhng): const REPO: &'static str = "rust";
@@ -15,7 +18,10 @@ pub const SEXXI_TEST_PROJECT: &'static str = "sexxi-webhook-test";
 pub const SEXXI_REMOTE_HOST: &'static str = "sorbitol";
 pub const SEXXI_LOG_FILE_DIR: &'static str = "www/build-logs";
 
-pub const BUILD_LOG_BASE_URL: &'static str = "https://csclub.uwaterloo.ca/~rlmmfruy/build-logs";
+lazy_static! {
+    pub static ref MACHINE_USER: String = env::var("USER").unwrap();
+    pub static ref BUILD_LOG_BASE_URL: String = format!("https://csclub.uwaterloo.ca/~{}/build-logs", *MACHINE_USER);
+}
 
 pub const COMMENT_JOB_START: &'static str = ":running_man: Start running build job";
 pub const COMMENT_JOB_DONE: &'static str = "✅ Job Completed";

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -15,8 +15,7 @@ pub const SEXXI_TEST_PROJECT: &'static str = "sexxi-webhook-test";
 pub const SEXXI_REMOTE_HOST: &'static str = "sorbitol";
 pub const SEXXI_LOG_FILE_DIR: &'static str = "www/build-logs";
 
-// TODO(azhng): we need to template out the user name here.
-pub const BUILD_LOG_BASE_URL: &'static str = "https://csclub.uwaterloo.ca/~[username]/build-logs";
+pub const BUILD_LOG_BASE_URL: &'static str = "https://csclub.uwaterloo.ca/~rlmmfruy/build-logs";
 
 pub const COMMENT_JOB_START: &'static str = ":running_man: Start running build job";
 pub const COMMENT_JOB_DONE: &'static str = "✅ Job Completed";

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -9,11 +9,14 @@ pub const SEXXI_GIT_DIR: &'static str = "$HOME/scratch/sexxi-rust/.git";
 pub const SEXXI_WORK_TREE: &'static str = "$HOME/scratch/sexxi-rust";
 pub const SEXXI_PROJECT: &'static str = "rust";
 
+// Default testing repo
+pub const SEXXI_TEST_PROJECT: &'static str = "sexxi-webhook-test";
+
 pub const SEXXI_REMOTE_HOST: &'static str = "sorbitol";
 pub const SEXXI_LOG_FILE_DIR: &'static str = "www/build-logs";
 
 // TODO(azhng): we need to template out the user name here.
-pub const BUILD_LOG_BASE_URL: &'static str = "https://csclub.uwaterloo.ca/~z577zhan/build-logs";
+pub const BUILD_LOG_BASE_URL: &'static str = "https://csclub.uwaterloo.ca/~[username]/build-logs";
 
 pub const COMMENT_JOB_START: &'static str = ":running_man: Start running build job";
 pub const COMMENT_JOB_DONE: &'static str = "✅ Job Completed";

--- a/src/lib/handler.rs
+++ b/src/lib/handler.rs
@@ -25,14 +25,14 @@ pub async fn handle_webhook(
     req: Request<Body>,
     jobs: Arc<RwLock<job::JobRegistry>>,
     sender: &mut mpsc::Sender<Uuid>,
-    curr_job: Arc<RwLock<job::JobInfo>>
+    curr_job: & Arc<RwLock<job::JobDesc>>
     ) -> Result<Response<Body>, hyper::Error> {
     let mut body = hyper::body::aggregate::<Request<Body>>(req).await?;
     let bytes = body.to_bytes();
     let blob: Result<serde_json::Value, serde_json::Error> = serde_json::from_slice(&bytes);
 
     match blob {
-        Ok(json) => parse_and_handle(json, jobs, sender, &curr_job).await,
+        Ok(json) => parse_and_handle(json, jobs, sender, curr_job).await,
         Err(e) => {
             error!("parsing error: {}", e);
             Ok::<_, hyper::Error>(gen_response(400))
@@ -96,7 +96,7 @@ async fn parse_and_handle(
     json: serde_json::Value,
     jobs: Arc<RwLock<job::JobRegistry>>,
     sender: &mut mpsc::Sender<Uuid>,
-    curr_job: &Arc<RwLock<job::JobInfo>>
+    curr_job: & Arc<RwLock<job::JobDesc>>
     ) -> Result<Response<Body>, hyper::Error> {
 
 
@@ -116,17 +116,18 @@ async fn parse_and_handle(
                 let job_id  = job.id.clone();
 
                 let mut jobs = jobs.write().await;
+                let temp_job = job.clone();
                 jobs.insert(job_id.clone(), Arc::new(RwLock::new(job)));
 
                 if head_ref == curr_job.read().await.head_ref {
                     info!("New job on same head_ref, killing current job");
                     // [To-Do] Fix, could potentially kill a process which is already dead
                     signal::kill(Pid::from_raw(curr_job.read().await.pid as i32), Signal::SIGKILL);
-                } else {
-                    {
-                        let mut w_curr_job = curr_job.write().await;
-                        w_curr_job.head_ref = String::from(head_ref);
-                    }
+                }
+
+                {
+                    let mut w_curr_job = curr_job.write().await;
+                    *w_curr_job = temp_job.clone();
                 }
 
                 if let Err(e) = sender.send(job_id).await {

--- a/src/lib/handler.rs
+++ b/src/lib/handler.rs
@@ -127,7 +127,7 @@ async fn parse_and_handle(
                             if head_ref == curr_job.head_ref {
                                 info!("New job on same head_ref, killing current job");
                                 // [To-Do] Fix, could potentially kill a process which is already dead
-                                signal::kill(Pid::from_raw(curr_job.pid as i32), Signal::SIGKILL);
+                                signal::kill(Pid::from_raw(curr_job.pid as i32), Signal::SIGINT);
                             }
                         }
                     }

--- a/src/lib/job.rs
+++ b/src/lib/job.rs
@@ -86,7 +86,7 @@ pub async fn process_job(job_id: &Uuid, job_registry: Arc<RwLock<JobRegistry>>) 
         job.status = JobStatus::Running;
     }
 
-    let copy_job : JobDesc;
+    let copy_job: JobDesc;
     {
         let job = &*job.read().await;
 
@@ -117,7 +117,7 @@ pub async fn process_job(job_id: &Uuid, job_registry: Arc<RwLock<JobRegistry>>) 
            a new job is started with the same key. ie: removing the key results
            in removing a running job not the canceled job.
         */
-        if (job.status != JobStatus::Canceled) {
+        if job.status != JobStatus::Canceled {
             {
                 let mut job_registry = job_registry.write().await;
                 job_registry.running_jobs.remove(&job.head_ref.clone());

--- a/src/lib/job.rs
+++ b/src/lib/job.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use super::{api, config, cmd};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum JobStatus {
     Created,
     Running,
@@ -53,15 +53,14 @@ impl JobDesc {
 #[derive(Debug)]
 pub struct JobRegistry {
     pub jobs : HashMap<Uuid, Arc<RwLock<JobDesc>>>,
-    pub running_jobs : Uuid, //head_ref to uuid
-    //pub running_jobs : HashMap<String,Uuid>, //head_ref to uuid
+    pub running_jobs : HashMap<String,Uuid>, //head_ref to uuid
 }
 
 impl JobRegistry {
     pub fn new() -> JobRegistry {
         JobRegistry {
             jobs: HashMap::new(),
-            running_jobs: Uuid::new_v4(),
+            running_jobs: HashMap::new(),
         }
     }
 }
@@ -111,6 +110,20 @@ pub async fn process_job(job_id: &Uuid, job_registry: Arc<RwLock<JobRegistry>>) 
 
     {
         let mut job = job.write().await;
+
+        /*
+           We don't want to remove the head_ref key from the cancelled
+           job if the JobStatus is Canceled because when a job is Canceled,
+           a new job is started with the same key. ie: removing the key results
+           in removing a running job not the canceled job.
+        */
+        if (job.status != JobStatus::Canceled) {
+            {
+                let mut job_registry = job_registry.write().await;
+                job_registry.running_jobs.remove(&job.head_ref.clone());
+            }
+        }
+
         if succeed {
             job.status = JobStatus::Finished;
         } else {
@@ -154,39 +167,39 @@ async fn run_and_build(job: &JobDesc, job_registry: &Arc<RwLock<JobRegistry>>) -
     }
 
 
-    if let Err(e) = cmd::remote_git_reset_branch(&mut log_file, job_registry).await {
+    if let Err(e) = cmd::remote_git_reset_branch(&job.id, &mut log_file, job_registry).await {
         return job_failure_handler("unable to reset branch", &job, e).await;
     }
 
-    if let Err(e) = cmd::remote_git_fetch_upstream(&mut log_file, job_registry).await {
+    if let Err(e) = cmd::remote_git_fetch_upstream(&job.id, &mut log_file, job_registry).await {
         return job_failure_handler("unable to fetch upstream", &job, e).await;
     }
 
-    if let Err(e) = cmd::remote_git_checkout_sha(&job.sha, &bot_ref, &mut log_file, job_registry).await {
+    if let Err(e) = cmd::remote_git_checkout_sha(&job.id, &job.sha, &bot_ref, &mut log_file, job_registry).await {
         return job_failure_handler("unable to check out commit", &job, e).await;
     }
 
-    if let Err(e) = cmd::remote_git_rebase_upstream(&mut log_file, job_registry).await {
+    if let Err(e) = cmd::remote_git_rebase_upstream(&job.id, &mut log_file, job_registry).await {
         return job_failure_handler("unable to rebase against upstream", &job, e).await;
     }
 
     // TODO(azhng): make this a runtime decision.
     //info!("Skipping running test for development");
-    if let Err(e) = cmd::remote_test_rust_repo(&mut log_file, job_registry).await {
-        cmd::remote_git_reset_branch(&mut log_file, job_registry).await.expect("Ok");
-        cmd::remote_git_delete_branch(&bot_ref, &mut log_file, job_registry).await.expect("Ok");
+    if let Err(e) = cmd::remote_test_rust_repo(&job.id, &mut log_file, job_registry).await {
+        cmd::remote_git_reset_branch(&job.id, &mut log_file, job_registry).await.expect("Ok");
+        cmd::remote_git_delete_branch(&job.id, &bot_ref, &mut log_file, job_registry).await.expect("Ok");
         return job_failure_handler("unit test failed", &job, e).await;
     }
 
-    if let Err(e) = cmd::remote_git_push(&bot_ref, &mut log_file, job_registry).await {
+    if let Err(e) = cmd::remote_git_push(&job.id, &bot_ref, &mut log_file, job_registry).await {
         return job_failure_handler("unable to push bot branch", &job, e).await;
     }
 
-    if let Err(e) = cmd::remote_git_reset_branch(&mut log_file, job_registry).await {
+    if let Err(e) = cmd::remote_git_reset_branch(&job.id, &mut log_file, job_registry).await {
         return job_failure_handler("unable to reset branch for clean up", &job, e).await;
     }
 
-    if let Err(e) = cmd::remote_git_delete_branch(&bot_ref, &mut log_file, job_registry).await {
+    if let Err(e) = cmd::remote_git_delete_branch(&job.id, &bot_ref, &mut log_file, job_registry).await {
         return job_failure_handler("unable to delete bot branch", &job, e).await;
     }
 


### PR DESCRIPTION
This PR is still a work in progress, but so far this is what has been done:
- Retrieve PID of process running job
- Updated 2 git commands
   - Use `-B` instead of `-b` for creating new branch. (`-B` create the new branch only if the branch does not exists, otherwise it resets the branch
   - Added `-p` to the `git fetch --all` command, since @arora-aman mentioned it was better

Next to implement:

- [x] Figure out the best way to keep track of the process PID so we can easily terminate processes and implement it

Closes sexxi-goose/sexxi-sync#6