### PR TITLE
webhook: remove deep clone of JobDesc in the worker.

### DIFF
--- a/src/lib/cmd.rs
+++ b/src/lib/cmd.rs
@@ -1,15 +1,9 @@
 use std::fs::File;
-use std::process::{Command, Stdio};
-use std::sync::Arc;
-use tokio::sync::RwLock;
-use uuid::Uuid;
-use nix::sys::signal::{self, Signal};
-
-use crate::lib::job;
+use std::process::{Child, Command, Stdio};
 
 use super::config;
 
-async fn remote_cmd(job_id: &Uuid, args: &mut Vec<&str>, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+async fn remote_cmd(args: &mut Vec<&str>, output: &mut File) -> Result<Child, String> {
     let output_file = output.try_clone().unwrap();
     let error_file = output.try_clone().unwrap();
     let cmd_process = Command::new("ssh")
@@ -21,82 +15,61 @@ async fn remote_cmd(job_id: &Uuid, args: &mut Vec<&str>, output: &mut File, job_
 
     match cmd_process {
         Ok(child) => {
-            info!("Server process with pid {} is running command `{:?}`", child.id(), args);
-            {
-                let job_registry = job_registry.read().await;
-                let job: Arc<RwLock<job::JobDesc>>;
-                if let Some(j) = job_registry.jobs.get(job_id) {
-                    job = j.clone();
-                    let mut job = job.write().await;
-                    job.pid = child.id();
-                }
-            }
-
-            let result = child.wait_with_output().expect("Ok");
-            if !result.status.success() {
-                /*
-                   Check if Signal::SIGINT was received. If it was the case
-                   this is probably because the the job was canceled.
-                   exit code 130 is a result of Control-C/SIGINT
-                */
-                if result.status.to_string() == "exit code: 130" {
-                    let job_registry = job_registry.read().await;
-                    let job: Arc<RwLock<job::JobDesc>>;
-                    if let Some(j) = job_registry.jobs.get(job_id) {
-                        job = j.clone();
-                        let mut job = job.write().await;
-                        job.status = job::JobStatus::Canceled;
-                    }
-                }
-                return Err(format!("remote command failed: {}", result.status));
-            }
+            info!("Server process with pid {} is running command `{:?}`", &child.id(), args);
+            return Ok(child);
         },
         Err(e) => {
-            return Err(format!("Command `{:?}` failed, server process didn't start: {}", args, e));
+            return Err(format!("command `{:?}` failed, server process didn't start: {}", args, e));
         },
-
     }
-
-    Ok(())
 }
 
-async fn remote_git_cmd(job_id: &Uuid, args: &mut Vec<&str>, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+async fn remote_git_cmd(args: &mut Vec<&str>, output: &mut File) -> Result<(), String> {
     let mut git_cmd = vec!["git", "-C", config::SEXXI_WORK_TREE];
     git_cmd.append(args);
-    remote_cmd(job_id, &mut git_cmd, output, job_registry).await
+    match remote_cmd(&mut git_cmd, output).await {
+        Ok(child) => {
+            let result = child.wait_with_output().expect("Ok");
+            if !result.status.success() {
+                return Err(format!("remote command failed: {}", result.status));
+            }
+            Ok(())
+        },
+        Err(e) => Err(format!("remote command failed: {}", e))
+    }
 }
 
-pub async fn remote_git_reset_branch(job_id: &Uuid, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_reset_branch(output: &mut File) -> Result<(), String> {
     let mut cmd = vec!["checkout", "master"];
-    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
+    remote_git_cmd(&mut cmd, output).await
 }
 
-pub async fn remote_git_fetch_upstream(job_id: &Uuid, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_fetch_upstream(output: &mut File) -> Result<(), String> {
     let mut cmd = vec!["fetch", "--all", "-p"];
-    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
+    remote_git_cmd(&mut cmd, output).await
 }
 
-pub async fn remote_git_checkout_sha(job_id: &Uuid, sha: &str, bot_ref: &str, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_checkout_sha(sha: &str, bot_ref: &str, output: &mut File) -> Result<(), String> {
     let mut cmd = vec!["checkout", sha, "-B", bot_ref];
-    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
+    remote_git_cmd(&mut cmd, output).await
 }
 
-pub async fn remote_git_rebase_upstream(job_id: &Uuid, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_rebase_upstream(output: &mut File) -> Result<(), String> {
     let mut cmd = vec!["rebase", "upstream/master"];
-    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
+    remote_git_cmd(&mut cmd, output).await
 }
 
-pub async fn remote_git_push(job_id: &Uuid, bot_ref: &str, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_push(bot_ref: &str, output: &mut File) -> Result<(), String> {
     let mut cmd = vec!["push", "origin", bot_ref, "-f"];
-    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
+    remote_git_cmd(&mut cmd, output).await
 }
 
-pub async fn remote_git_delete_branch(job_id: &Uuid, bot_ref: &str, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_git_delete_branch(bot_ref: &str, output: &mut File) -> Result<(), String> {
     let mut cmd = vec!["branch", "-D", bot_ref];
-    remote_git_cmd(job_id, &mut cmd, output, job_registry).await
+    remote_git_cmd(&mut cmd, output).await
 }
 
-pub async fn remote_test_rust_repo(job_id: &Uuid, output: &mut File, job_registry: &Arc<RwLock<job::JobRegistry>>) -> Result<(), String> {
+pub async fn remote_test_rust_repo(output: &mut File) -> Result<Child, String> {
     let mut cmd = vec![
         "cd",
         config::SEXXI_WORK_TREE,
@@ -106,5 +79,5 @@ pub async fn remote_test_rust_repo(job_id: &Uuid, output: &mut File, job_registr
         "-i",
         "-j32",
     ];
-    remote_cmd(job_id, &mut cmd, output, job_registry).await
+    remote_cmd(&mut cmd, output).await
 }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -1,7 +1,9 @@
-use std::env;
 use lazy_static::lazy_static;
+use std::env;
 
 pub const REVIEW_REQUESTED: &'static str = "review_requested";
+pub const REVIEW_REQUESTED_REMOVED: &'static str = "review_requested_removed";
+
 pub const REVIEWER: &'static str = "sexxi-bot";
 // TODO(azhng): const REPO: &'static str = "rust";
 
@@ -20,7 +22,8 @@ pub const SEXXI_LOG_FILE_DIR: &'static str = "www/build-logs";
 
 lazy_static! {
     pub static ref MACHINE_USER: String = env::var("USER").unwrap();
-    pub static ref BUILD_LOG_BASE_URL: String = format!("https://csclub.uwaterloo.ca/~{}/build-logs", *MACHINE_USER);
+    pub static ref BUILD_LOG_BASE_URL: String =
+        format!("https://csclub.uwaterloo.ca/~{}/build-logs", *MACHINE_USER);
 }
 
 pub const COMMENT_JOB_START: &'static str = ":running_man: Start running build job";


### PR DESCRIPTION
* Also removed additional hashmap lookup after retrieval of
  JobDesc in the beginning of the worker.
* Remove 'cmd' module's dependency on the 'job' module. The
  responsibility of updating job status is pushed up to job
  module.

Closes #2 

This PR essentially move the some of the JobDesc updating code from `cmd.rs` to `job.rs` and replace a deep clone of `JobDesc` with a clone of the Arc wrapping around it. 

Also made a choice here to only keep track of the PID of the `./x.py` process, consequentially this means we will not be able to kill the job that's still doing git fetching and rebasing etc. This is because if we kill the `git` processes, we might leave the repo in a corrupted state. But it is ok for us to kill the `./x.py` process since there's cleanup logic in place to clean up the repo afterwards. However, this means we should probably improve our error handling somehow. 