### PR TITLE
Cancelling running jobs when specific conditions are met

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,12 +129,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -142,6 +158,35 @@ name = "futures-core"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -154,6 +199,9 @@ name = "futures-task"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
@@ -161,10 +209,18 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -457,6 +513,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+
+[[package]]
 name = "openssl"
 version = "0.10.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +604,18 @@ dependencies = [
  "env_logger",
  "log",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -702,6 +776,7 @@ name = "sexxi-webhook"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "futures",
  "hyper",
  "hyper-tls",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 nix = "0.17"
 lazy_static = "1.4"
+futures = "0.3"

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -2,8 +2,7 @@ use lazy_static::lazy_static;
 use std::env;
 
 pub const REVIEW_REQUESTED: &'static str = "review_requested";
-pub const REVIEW_REQUESTED_REMOVED: &'static str = "review_requested_removed";
-
+pub const REVIEW_REQUEST_REMOVED: &'static str = "review_request_removed";
 pub const REVIEWER: &'static str = "sexxi-bot";
 // TODO(azhng): const REPO: &'static str = "rust";
 
@@ -19,6 +18,7 @@ pub const SEXXI_TEST_PROJECT: &'static str = "sexxi-webhook-test";
 
 pub const SEXXI_REMOTE_HOST: &'static str = "sorbitol";
 pub const SEXXI_LOG_FILE_DIR: &'static str = "www/build-logs";
+pub const SEXXI_TIMEOUT_JOB_IN_SEC: u64 = 60 * 60 * 2;
 
 lazy_static! {
     pub static ref MACHINE_USER: String = env::var("USER").unwrap();

--- a/src/lib/job.rs
+++ b/src/lib/job.rs
@@ -86,9 +86,10 @@ pub async fn process_job(job_id: &Uuid, job_registry: Arc<RwLock<JobRegistry>>) 
         error!("job {} failed due to: {}", &job_id, e);
     }
 
-    if job.read().await.status == JobStatus::Canceled {
-        job_registry.write().await.running_jobs.remove(&job.read().await.head_ref.clone());
-    }
+    // We should be removing the job from the running_jobs list when the job is no more running
+    info!("Job is no longer running, remove the job from the running_jobs list");
+    job_registry.write().await.running_jobs.remove(&job.read().await.head_ref.clone());
+
 }
 
 async fn job_failure_handler<T: std::fmt::Display>(
@@ -203,7 +204,6 @@ async fn run_and_build(job: &Arc<RwLock<JobDesc>>) -> Result<(), String> {
     Ok(())
 }
 
-
 async fn start_build_job(job: &Arc<RwLock<JobDesc>>) -> Result<(), String> {
     {
         let job = &*job.read().await;
@@ -212,5 +212,6 @@ async fn start_build_job(job: &Arc<RwLock<JobDesc>>) -> Result<(), String> {
             return Err(format!("failed to post comment to pr {}: {}", &job.pr_num, e));
         }
     }
+
     run_and_build(job).await
 }


### PR DESCRIPTION
This PR will allow the `sexxi-webhook` to cancel a running job when the following conditions are met:
- [x] When user manually cancels the job by unassigning the bot from reviewer assignee
- [ ] When user force push to the same branch and overwrite the commits
- [ ] Timeout

~~Some additional changes will be required once https://github.com/sexxi-goose/sexxi-webhook/pull/3 is merged.~~

Closes sexxi-goose/sexxi-sync#5